### PR TITLE
Implement support for *.trd images

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ LIST
 
 * Amstrad:      `DSK`, `CDT`
 * Commodore 64: `D64`, `D71`, `D81`, `T64`, `TAP`
-* ZX Spectrum:  `TZX`, `TAP`
+* ZX Spectrum:  `TZX`, `TAP`, `TRD`
 
 The `geometry` command will read and display core metadata about the layout
 of the media. This can be disk track and sector details, or the header and

--- a/cmd/spectrum_geometry.go
+++ b/cmd/spectrum_geometry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mrcook/retroio/spectrum"
 	"github.com/mrcook/retroio/spectrum/tap"
+	"github.com/mrcook/retroio/spectrum/trd"
 	"github.com/mrcook/retroio/spectrum/tzx"
 	"github.com/mrcook/retroio/storage"
 )
@@ -38,6 +39,8 @@ ZX Spectrum emulator TZX or TAP file.`,
 			dsk = tap.New(reader)
 		case "tzx":
 			dsk = tzx.New(reader)
+		case "trd":
+			dsk = trd.New(reader)
 		default:
 			fmt.Printf("Unsupported media type: '%s'", dskType)
 			return

--- a/spectrum/trd/disk_info.go
+++ b/spectrum/trd/disk_info.go
@@ -1,0 +1,62 @@
+package trd
+
+import (
+	"fmt"
+	"github.com/mrcook/retroio/storage"
+)
+
+// DiskInformation stores the disk information obtained from the 9th sector of the system track
+type DiskInformation struct {
+	NextFreeSector     uint8
+	NextFreeTrack      uint8
+	DiskType           DiskType
+	NumFiles           uint8
+	NumFreeSectors     uint16
+	NumDeletedFiles    uint8
+	Label              [8]byte
+}
+
+func (di *DiskInformation) Read(reader *storage.Reader) error {
+	if _, err := reader.Peek(256); err != nil {
+		return err
+	}
+
+	// Skip to position 225
+	reader.ReadBytes(225)
+
+	di.NextFreeSector = reader.ReadByte()
+	di.NextFreeTrack = reader.ReadByte()
+
+	di.DiskType = DiskType(reader.ReadByte())
+
+	di.NumFiles = reader.ReadByte()
+	di.NumFreeSectors = reader.ReadShort()
+
+	// Skip the number of sectors per track (MAIN_BYTE) which is always the same
+	reader.ReadByte()
+
+	// Skip two zero bytes
+	reader.ReadShort()
+
+	// Skip nine whitespaces
+	reader.ReadBytes(9)
+
+	// Skip one more zero byte
+	reader.ReadByte()
+
+	di.NumDeletedFiles = reader.ReadByte()
+	copy(di.Label[:], reader.ReadBytes(8))
+
+	return nil
+}
+
+func (di DiskInformation) String() string {
+	str := ""
+	str += fmt.Sprintf("Type:          %s\n", di.DiskType)
+	str += fmt.Sprintf("Label:         %s\n", di.Label)
+	str += fmt.Sprintf("Total files:   %d\n", di.NumFiles)
+	str += fmt.Sprintf("Deleted files: %d\n", di.NumDeletedFiles)
+	str += fmt.Sprintf("Free sectors:  %d\n", di.NumFreeSectors)
+
+	return str
+}

--- a/spectrum/trd/disk_type.go
+++ b/spectrum/trd/disk_type.go
@@ -1,0 +1,26 @@
+package trd
+
+// DiskType represents the possible values of the disk type
+type DiskType byte
+
+const (
+	Tracks80Sides2 DiskType = 0x16
+	Tracks40Sides2 DiskType = 0x17
+	Tracks80Sides1 DiskType = 0x18
+	Tracks40Sides1 DiskType = 0x19
+)
+
+func (dt DiskType) String() string {
+	switch dt {
+	case Tracks80Sides2:
+		return "80 tracks, double side"
+	case Tracks40Sides2:
+		return "40 tracks, double side"
+	case Tracks80Sides1:
+		return "80 tracks, single side"
+	case Tracks40Sides1:
+		return "40 tracks, single side"
+	}
+
+	return "unknown"
+}

--- a/spectrum/trd/file_info.go
+++ b/spectrum/trd/file_info.go
@@ -1,0 +1,70 @@
+package trd
+
+import (
+	"fmt"
+	"github.com/mrcook/retroio/storage"
+)
+
+// FileInformation represents a single file information obtained from the disk catalog
+type FileInformation struct {
+	Filename        [8]byte
+	FileType        FileType
+	StartAddress    uint16
+	LengthInBytes   uint16
+	LengthInSectors uint8
+	StartingSector  uint8
+	StartingTrack   uint8
+}
+
+func (i *FileInformation) Read(reader *storage.Reader) error {
+	if _, err := reader.Peek(16); err != nil {
+		return err
+	}
+
+	copy(i.Filename[:], reader.ReadBytes(8))
+
+	ext := reader.ReadByte()
+	switch ext {
+	case 'b':
+		fallthrough
+	case 'B':
+		i.FileType = &FileTypeBasic{}
+	case 'c':
+		fallthrough
+	case 'C':
+		i.FileType = &FileTypeCode{}
+	default:
+		i.FileType = &FileTypeOther{Extension: ext}
+	}
+
+	i.StartAddress = reader.ReadShort()
+	i.LengthInBytes = reader.ReadShort()
+	i.LengthInSectors = reader.ReadByte()
+	i.StartingSector = reader.ReadByte()
+	i.StartingTrack = reader.ReadByte()
+
+	return nil
+}
+
+// IsDeleted returns whether the given entry represents a deleted file
+// The procedure for deleting a file is to replace the first byte of its name with the code 0x00 or 0x01.
+func (i FileInformation) IsDeleted() bool {
+	switch i.Filename[0] {
+	case 0x00:
+		fallthrough
+	case 0x01:
+		return true
+	}
+
+	return false
+}
+
+func (i FileInformation) String() string {
+	str := fmt.Sprintf("%s\n", i.FileType.Name())
+	str += fmt.Sprintf(" - Filename:    %s\n", i.Filename)
+	str += fmt.Sprintf(" - Sectors:     %d\n", i.LengthInSectors)
+	str += fmt.Sprintf(" - Bytes:       %d\n", i.LengthInBytes)
+	str += i.FileType.Info(i)
+
+	return str
+}

--- a/spectrum/trd/file_type.go
+++ b/spectrum/trd/file_type.go
@@ -1,0 +1,40 @@
+package trd
+
+import "fmt"
+
+type FileType interface {
+	Name() string
+	Info(info FileInformation) string
+}
+
+type FileTypeBasic struct{}
+
+func (t *FileTypeBasic) Name() string {
+	return "BASIC Program"
+}
+
+func (t *FileTypeBasic) Info(i FileInformation) string {
+	return ""
+}
+
+type FileTypeCode struct{}
+
+func (t *FileTypeCode) Name() string {
+	return "Code (bytes)"
+}
+
+func (t *FileTypeCode) Info(i FileInformation) string {
+	return fmt.Sprintf(" - Address:     %d\n", i.StartAddress)
+}
+
+type FileTypeOther struct{
+	Extension byte
+}
+
+func (t *FileTypeOther) Name() string {
+	return fmt.Sprintf("Other type (%c)", t.Extension)
+}
+
+func (t *FileTypeOther) Info(i FileInformation) string {
+	return ""
+}

--- a/spectrum/trd/trd.go
+++ b/spectrum/trd/trd.go
@@ -1,0 +1,64 @@
+// https://faqwiki.zxnet.co.uk/wiki/TR-DOS_filesystem
+// http://www.8bit-wiki.de/index.php?id=3&filt=Sinclair/ZX_Spectrum/interfaces/betadisk/_manual/&cid=16062&mode=dl&tx=330ea210000
+package trd
+
+import (
+	"fmt"
+	"github.com/mrcook/retroio/storage"
+)
+
+type TRD struct {
+	reader *storage.Reader
+
+	Files []FileInformation
+	Info  DiskInformation
+}
+
+func New(reader *storage.Reader) *TRD {
+	return &TRD{reader: reader}
+}
+
+// Read processes each TAP/BLK block in the tape file.
+func (t *TRD) Read() error {
+	var descriptors [128]FileInformation
+
+	for i := 0; i < len(descriptors); i++ {
+		err := descriptors[i].Read(t.reader)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	info := DiskInformation{}
+	err := info.Read(t.reader)
+
+	if err != nil {
+		return err
+	}
+
+	t.Info = info
+
+	t.Files = descriptors[:info.NumFiles]
+
+	return nil
+}
+
+// DisplayGeometry outputs the metadata of the disk and its files to the terminal.
+func (t TRD) DisplayGeometry() {
+	fmt.Println("DISK INFORMATION:")
+	fmt.Println(t.Info)
+
+	fmt.Println("FILES:")
+	for i, file := range t.Files {
+		if file.IsDeleted() {
+			continue
+		}
+		fmt.Printf("#%03d %s\n", i+1, file.String())
+	}
+}
+
+// DisplayBASIC outputs all BASIC programs on the disk
+func (t TRD) DisplayBASIC() {
+	fmt.Println("Not implemented for Spectrum disk images")
+}


### PR DESCRIPTION
This patch adds support for displaying the geometry of `*.trd` [TR-DOS](https://en.wikipedia.org/wiki/TR-DOS) disk images for ZX-Spectrum. The support for displaying BASIC programs is not added since it's more complicated than for tape images and doesn't seem to be implemented for the disk images of other platforms.

Example output using [Dizzy and the Mystical Letter](http://www.indieretronews.com/2018/07/dizzy-and-mystical-letter-new-dizzy.html):
```
$ rio spectrum geometry game_en.trd

DISK INFORMATION:
Type:          80 tracks, double side
Label:                 
Total files:   16
Deleted files: 0
Free sectors:  2122

FILES:
#001 BASIC Program
 - Filename:    boot    
 - Sectors:     1
 - Bytes:       82

#002 Code (bytes)
 - Filename:    code    
 - Sectors:     82
 - Bytes:       20928
 - Address:     24576

#003 Code (bytes)
 - Filename:    scripts 
 - Sectors:     18
 - Bytes:       4535
 - Address:     24576

#004 Code (bytes)
 - Filename:    sndlib  
 - Sectors:     10
 - Bytes:       2487
 - Address:     24576

#005 Code (bytes)
 - Filename:    sounds  
 - Sectors:     4
 - Bytes:       940
 - Address:     24576

#006 Code (bytes)
 - Filename:    title1  
 - Sectors:     27
 - Bytes:       6912
 - Address:     24576

#007 Code (bytes)
 - Filename:    title2  
 - Sectors:     27
 - Bytes:       6912
 - Address:     24576

...
```